### PR TITLE
#41 - [Home page] fixed styles for  item descriptions in “How it works” block

### DIFF
--- a/src/components/title-with-description/TitleWithDescription.tsx
+++ b/src/components/title-with-description/TitleWithDescription.tsx
@@ -1,10 +1,10 @@
 import { ReactElement, ReactNode, useState } from 'react'
-import { SxProps } from '@mui/material'
-import Tooltip from '@mui/material/Tooltip'
-import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
 
-import { styles } from '~/components/title-with-description/TitleWithDescription.styles'
+import { SxProps } from '@mui/material'
+import Box from '@mui/material/Box'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { styles } from './TitleWithDescription.styles'
 
 interface TitleWithDescriptionProps {
   title: string | ReactElement

--- a/src/containers/guest-home-page/cards-with-button/CardsWithButton.styles.ts
+++ b/src/containers/guest-home-page/cards-with-button/CardsWithButton.styles.ts
@@ -1,6 +1,6 @@
 import {
-  slidesRightAnimation,
-  slidesLeftAnimation
+  slidesLeftAnimation,
+  slidesRightAnimation
 } from '~/styles/app-theme/custom-animations'
 
 const side = {
@@ -28,7 +28,7 @@ const side = {
     marginBottom: '8px'
   },
   description: {
-    typography: { xs: 'subtitle2' }
+    typography: { xs: 'body2' }
   }
 }
 

--- a/src/containers/guest-home-page/cards-with-button/CardsWithButton.tsx
+++ b/src/containers/guest-home-page/cards-with-button/CardsWithButton.tsx
@@ -8,14 +8,13 @@ import Box from '@mui/material/Box'
 import AppButton from '~/components/app-button/AppButton'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import dots from '~/assets/img/guest-home-page/dots.svg'
-
 import {
   AccordionWithImageItem,
   PositionEnum,
   SizeEnum,
   UserRoleEnum
 } from '~/types'
-import { styles } from '~/containers/guest-home-page/cards-with-button/CardsWithButton.styles'
+import { styles } from './CardsWithButton.styles'
 
 interface CardsWithButtonProps {
   array: AccordionWithImageItem[]
@@ -50,7 +49,7 @@ const CardsWithButton: FC<CardsWithButtonProps> = ({
             <Box className='dots' component='img' src={dots} />
           </Box>
           <TitleWithDescription
-            description={t(item.description)}
+            description={t(item.description ?? '')}
             style={styles[boxSide]}
             title={t(item.title)}
           />

--- a/src/containers/guest-home-page/how-it-works/HowItWorks.tsx
+++ b/src/containers/guest-home-page/how-it-works/HowItWorks.tsx
@@ -3,17 +3,12 @@ import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-
 import CardsWithButton from '~/containers/guest-home-page/cards-with-button/CardsWithButton'
 import AppContentSwitcher from '~/components/app-content-switcher/AppContentSwitcher'
-import {
-  tutorCardBoxArray,
-  studentCardBoxArray
-} from '~/containers/guest-home-page/how-it-works/CardBoxArrays'
 import { guestRoutes } from '~/router/constants/guestRoutes'
-
 import { TypographyVariantEnum, UserRoleEnum } from '~/types'
-import { styles } from '~/containers/guest-home-page/how-it-works/HowItWorks.styles'
+import { studentCardBoxArray, tutorCardBoxArray } from './CardBoxArrays'
+import { styles } from './HowItWorks.styles'
 
 const HowItWorks = () => {
   const { t } = useTranslation()

--- a/src/pages/guest-home-page/GuestHome.tsx
+++ b/src/pages/guest-home-page/GuestHome.tsx
@@ -2,19 +2,18 @@ import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
 import Box from '@mui/material/Box'
-
-import { descriptionTimes } from '~/components/accordion-with-image/accordion-with-image.constants'
-import PageWrapper from '~/components/page-wrapper/PageWrapper'
 import EmailConfirmModal from '~/containers/email-confirm-modal/EmailConfirmModal'
 import FeatureBlock from '~/containers/guest-home-page/FeatureBlock'
-import Welcome from '~/containers/guest-home-page/Welcome'
-import WhatCanYouDo from '~/containers/guest-home-page/WhatCanYouDo'
 import HowItWorks from '~/containers/guest-home-page/how-it-works/HowItWorks'
 import LoginDialog from '~/containers/guest-home-page/login-dialog/LoginDialog'
 import ResetPassword from '~/containers/guest-home-page/reset-password/ResetPassword'
+import Welcome from '~/containers/guest-home-page/Welcome'
+import WhatCanYouDo from '~/containers/guest-home-page/WhatCanYouDo'
 import WhoWeAre from '~/containers/guest-home-page/who-we-are/WhoWeAre'
+import { descriptionTimes } from '~/components/accordion-with-image/accordion-with-image.constants'
+import PageWrapper from '~/components/page-wrapper/PageWrapper'
 import { useModalContext } from '~/context/modal-context'
-import { styles } from '~/pages/guest-home-page/GuestHome.styles'
+import { styles } from './GuestHome.styles'
 
 const GuestHomePage = () => {
   const { openModal } = useModalContext()


### PR DESCRIPTION
fixed prettier errors (sort imports) for GuestHomePage 
fixed prettier errors (sort imports) for HowItWorks 
fixed prettier errors (sort imports) for CardsWithButtonProps 
fixed prettier errors (sort imports) for TitleWithDescriptionProps 
changed description styles in CardsWithButton.styles.ts on correct styles (body2)