### PR TITLE
test for app-content-switcher

### DIFF
--- a/src/components/app-content-switcher/AppContentSwitcher.tsx
+++ b/src/components/app-content-switcher/AppContentSwitcher.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react'
-import { TypographyProps } from '@mui/material/Typography'
+
 import { Typography } from '@mui/material'
-import { SxProps } from '@mui/system'
-import Tooltip from '@mui/material/Tooltip'
-import Switch from '@mui/material/Switch'
 import Stack from '@mui/material/Stack'
+import Switch from '@mui/material/Switch'
+import Tooltip from '@mui/material/Tooltip'
+import { TypographyProps } from '@mui/material/Typography'
+import { SxProps } from '@mui/system'
 import { defaultStyles } from '~/components/app-content-switcher/AppContentSwitcher.styles'
 import { SwitchContent, SwitchOptions } from '~/types'
 

--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { vi } from 'vitest'
 
 import AppContentSwitcher from '~/components/app-content-switcher/AppContentSwitcher'
 

--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import AppContentSwitcher from '~/components/app-content-switcher/AppContentSwitcher'
+
+const tooltips = {
+  left: { text: 'this one' },
+  right: { text: 'another one' }
+}
+
+const props = {
+  active: true,
+  onChange: vi.fn(),
+  switchOptions: tooltips,
+  typographyVariant: 'h2',
+  styles: { margin: '5px' }
+}
+
+describe('AppContentSwitcher', () => {
+  beforeEach(() => {
+    render(<AppContentSwitcher {...props} />)
+  })
+
+  it('should render with the correct props', () => {
+    const switcher = screen.getByRole('checkbox')
+    const headings = screen.getAllByRole('heading', { level: 2 })
+
+    expect(switcher.checked).toEqual(props.active)
+    expect(headings.length).toBeGreaterThan(0)
+    expect(headings[0].parentElement).toHaveStyle('margin: 5px')
+  })
+
+  it('should call the onChange function when the switch is clicked', () => {
+    const switcher = screen.getByRole('checkbox')
+    fireEvent.click(switcher)
+
+    expect(props.onChange).toHaveBeenCalled()
+  })
+
+  it('should renders tooltips when tooltip props are passed', () => {
+    const leftTooltip = screen.getByText(tooltips.left.text)
+    const rightTooltip = screen.getByText(tooltips.right.text)
+
+    expect(leftTooltip).toBeInTheDocument()
+    expect(rightTooltip).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Write test due to card task :

Test cases:

it should render with the correct props

it should call the onChange function when the switch is clicked

it should renders tooltips when tooltip props are passed